### PR TITLE
Bug when closing reopened chronicle

### DIFF
--- a/src/main/java/vanilla/java/chronicle/impl/IndexedChronicle.java
+++ b/src/main/java/vanilla/java/chronicle/impl/IndexedChronicle.java
@@ -209,7 +209,9 @@ public class IndexedChronicle extends AbstractChronicle {
     private void clearAll(FileChannel channel, List<MappedByteBuffer> buffers) {
         try {
             for (MappedByteBuffer buffer : buffers) {
-                buffer.force();
+                if (buffer != null) {
+                    buffer.force();
+                }
             }
         } finally {
             try {

--- a/src/test/java/vanilla/java/chronicle/impl/IndexedChronicleTest.java
+++ b/src/test/java/vanilla/java/chronicle/impl/IndexedChronicleTest.java
@@ -68,6 +68,31 @@ public class IndexedChronicleTest {
         tsc.close();
     }
 
+    /**
+     * Tests that <code>IndexedChronicle.close()</code> does not blow up (anymore) when you
+     * reopen an existing chronicle due to the null data buffers created internally.
+     *
+     * @throws java.io.IOException if opening chronicle fails
+     */
+    @Test
+    public void testCloseWithNullBuffers() throws IOException {
+        String basePath = "/tmp/deleteme.ict";
+        IndexedChronicle tsc = new IndexedChronicle(basePath, 12);
+        deleteOnExit(basePath);
+
+        tsc.clear();
+        Excerpt excerpt = tsc.createExcerpt();
+        for (int i = 0; i < 512; i++) {
+            excerpt.startExcerpt(1);
+            excerpt.writeByte(1);
+            excerpt.finish();
+        }
+        tsc.close();
+
+        tsc = new IndexedChronicle(basePath, 12);
+        tsc.close();
+    }
+
 
     private static void deleteOnExit(String basePath) {
         new File(basePath + ".data").deleteOnExit();


### PR DESCRIPTION
Hi Peter,

We ran into a NPE when closing a chronicle we had reopened. The process of reopening the chronicle potentially creates null index/data buffers, which needs to be catered for when closing the chronicle. Fix and test case attached.

Cheers
Craig
