### PR TITLE
Fixing documentation for excerpt startExcerpt() method

### DIFF
--- a/chronicle/src/main/java/com/higherfrequencytrading/chronicle/Excerpt.java
+++ b/chronicle/src/main/java/com/higherfrequencytrading/chronicle/Excerpt.java
@@ -95,7 +95,7 @@ public interface Excerpt extends RandomDataInput, RandomDataOutput, ByteStringAp
     /**
      * Start a new excerpt in the Chronicle.
      *
-     * @param capacity minimum capacity to allow for.
+     * @param capacity maximum excerpt capacity in bytes.
      */
     void startExcerpt(int capacity);
 


### PR DESCRIPTION
Capacity is actually maximum amount of data we can write to it.
