### PR TITLE
testing and demo should use current snapshot as a parent

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.higherfrequencytrading</groupId>
         <artifactId>chronicle-parent</artifactId>
-        <version>1.7.2-SNAPSHOT</version>
+        <version>1.7.3-SNAPSHOT</version>
     </parent>
 
     <groupId>com.higherfrequencytrading</groupId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.higherfrequencytrading</groupId>
         <artifactId>chronicle-parent</artifactId>
-        <version>1.7.2-SNAPSHOT</version>
+        <version>1.7.3-SNAPSHOT</version>
     </parent>
 
     <groupId>com.higherfrequencytrading</groupId>


### PR DESCRIPTION
build of modules demo and testing is broken unless there is a chronicle version 1.7.2 in a local repository.
