### PR TITLE
algin junit version by deleting explicitly declared version in chroni…

### DIFF
--- a/chronicle-fix/pom.xml
+++ b/chronicle-fix/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.10</version>
+                <version>4.13</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
…cle-fix/pom.xml and it will automatically pick the version in parent pom.xml. Update junit version to 4.13. Aligin junit versions to avoid inconsistent API behaviors.